### PR TITLE
Change default of GitVersion from 5.6.3 to 5.11.x

### DIFF
--- a/blueprints/__101__/azure-pipeline-__101__-control.yml
+++ b/blueprints/__101__/azure-pipeline-__101__-control.yml
@@ -19,7 +19,7 @@ parameters:
 # CI Blueprint optionals
 - name:     versionSpec
   type:     string
-  default:  '5.6.3' #interim hotfix until we fix latest git tools versions
+  default:  '5.11.x' # change default from 5.6.3 to 5.11.x 
 # CD Blueprint optionals
 - name:     suppressCD
   type:     boolean

--- a/blueprints/azure-function/azure-pipeline-azure-function-control.yml
+++ b/blueprints/azure-function/azure-pipeline-azure-function-control.yml
@@ -21,7 +21,7 @@ parameters:
 # CI Blueprint optionals
 - name:     versionSpec
   type:     string
-  default:  '5.6.3' #interim hotfix until we fix latest git tools versions
+  default:  '5.11.x' # change default from 5.6.3 to 5.11.x 
 # CD Blueprint optionals
 - name:     suppressCD
   type:     boolean

--- a/blueprints/nuget-package/azure-pipeline-nuget-package-control.yml
+++ b/blueprints/nuget-package/azure-pipeline-nuget-package-control.yml
@@ -30,7 +30,7 @@ parameters:
 # CI Blueprint optionals
 - name:     versionSpec
   type:     string
-  default:  '5.6.3' #interim hotfix until we fix latest git tools versions
+  default:  '5.11.x' # change default from 5.6.3 to 5.11.x 
 - name:     useDefaultConfig
   type:     boolean
   default:  false

--- a/blueprints/universal-artifact/azure-pipeline-universal-artifact-control.yml
+++ b/blueprints/universal-artifact/azure-pipeline-universal-artifact-control.yml
@@ -18,7 +18,7 @@ parameters:
 # CI Blueprint optionals
 - name:     versionSpec
   type:     string
-  default:  '5.6.3' #interim hotfix until we fix latest git tools versions
+  default:  '5.11.x' # change default from 5.6.3 to 5.11.x 
 # CD Blueprint optionals
 - name:     suppressCD
   type:     boolean

--- a/templates/utilities/git-tools-git-version.yml
+++ b/templates/utilities/git-tools-git-version.yml
@@ -42,7 +42,7 @@ parameters:
   default:  ''  # TODO: to be removed once this parameter is not optional
 - name:     versionSpec
   type:     string
-  default:  '5.6.3' #interim hotfix until we fix latest git tools versions
+  default:  '5.11.x' # change default from 5.6.3 to 5.11.x 
 - name:     useConfigFile
   type:     boolean
   default:  false


### PR DESCRIPTION
We used to default to GitVersion 5.6.3 to avoid formatting issues introduced with later versions. As 5.11.1 is not showing these issues we can update the default to the latest  Major = 5 and Minor = 11, namely 5.11.x.