### PR TITLE
Add lo and hi placeholders

### DIFF
--- a/templates/dev-sec-ops/security-scans-auto.yml
+++ b/templates/dev-sec-ops/security-scans-auto.yml
@@ -21,3 +21,8 @@ steps:
   - script: echo 'Security CD Higher Environment Automation Placeholder ****************************************'
   - script: echo applicationBlueprint = ${{parameters.applicationBlueprint}}
   - script: echo modeElite = ${{parameters.modeElite}}
+
+# -----------------------------------------------------------------------------------------------------
+# SECURITY AUTOMATION FOR LOWER AND HIGHER (PROD) ENVIRONMENTS STAGE
+# -----------------------------------------------------------------------------------------------------
+- script: echo 'Security CD Lower and Higher Environment Automation Placeholder ***********************************'

--- a/templates/qa/qa-scans-cd.yml
+++ b/templates/qa/qa-scans-cd.yml
@@ -45,3 +45,20 @@ steps:
 
   - ${{ if and(ne(lower(parameters.applicationBlueprint),'universal-artifact'), ne(lower(parameters.applicationBlueprint),'nuget-package'), ne(lower(parameters.applicationBlueprint),'azure-function')) }}:
     - script: echo UNKNOWN application type
+
+# -----------------------------------------------------------------------------------------------------
+# QA AUTOMATION FOR LOWER AND HIGHER (PROD) ENVIRONMENTS STAGE
+# -----------------------------------------------------------------------------------------------------
+- script: echo 'QA CD Lower and Higher Environment Automation Placeholder ***********************************'
+
+- ${{ if eq( lower(parameters.applicationlueprint), 'azure-function' ) }}:
+  - script: echo deal with qa scan relevant to azure-function application type
+
+- ${{ if eq( lower(parameters.applicationBlueprint), 'nuget-package' ) }}:
+  - script: echo deal with qa scan relevant to nuget-package application type
+
+- ${{ if eq( lower(parameters.applicationBlueprint), 'universal-artifact' ) }}:
+  - script: echo deal with qa scan relevant to universal-artifact application type
+
+- ${{ if and(ne(lower(parameters.applicationBlueprint),'universal-artifact'), ne(lower(parameters.applicationBlueprint),'nuget-package'), ne(lower(parameters.applicationBlueprint),'azure-function')) }}:
+  - script: echo UNKNOWN application type


### PR DESCRIPTION
Add placeholders for low, high, and for Low+high environments on security and QA templates. Idea came from in-flight conditional blog post.