### PR TITLE
Remove modeElite from start templates

### DIFF
--- a/blueprints/__101__/azure-pipeline-__101__-start.yml
+++ b/blueprints/__101__/azure-pipeline-__101__-start.yml
@@ -40,4 +40,3 @@ extends:
     productName:     '__TODO_PRODUCT__'
     publishFolder:   '__TODO_FOLDERNAME__'
     suppressCD:      true # Allow engineering to do an immediate CI/build while CD is being configured
-    modeElite:       false

--- a/blueprints/azure-function/azure-pipeline-azure-function-start.yml
+++ b/blueprints/azure-function/azure-pipeline-azure-function-start.yml
@@ -36,4 +36,3 @@ extends:
     productName:        '__TODO_PRODUCT__'
     azFuncProjectName:  '__TODO_AZURE_FUNCTION_PROJECT_NAME__' # e.g. CeS.Sample.AzureFunction
     suppressCD:         true # Allow engineering to do an immediate CI/build while CD is being configured
-    modeElite:          false

--- a/blueprints/nuget-package/azure-pipeline-nuget-package-start.yml
+++ b/blueprints/nuget-package/azure-pipeline-nuget-package-start.yml
@@ -44,5 +44,4 @@ extends:
     projectFile:            '__TODO_PROJECT_FILE__'             # e.g. wcbCAPTCHACtrl.csproj
     nuspecFile:             '__TODO_NUSPEC_FILE__'              # e.g. wcbCAPTCHACtrl.nuspec
     suppressCD:             false                               # Allow engineering to do an immediate CI/build while CD is being configured
-    modeElite:              false
     verbose:                true                                # remove once development is completed

--- a/blueprints/universal-artifact/azure-pipeline-universal-artifact-start.yml
+++ b/blueprints/universal-artifact/azure-pipeline-universal-artifact-start.yml
@@ -37,4 +37,3 @@ extends:
     productName:     '__TODO_PRODUCT__'
     publishFolder:   '__TODO_FOLDERNAME__'
     suppressCD:      true # Allow engineering to do an immediate CI/build while CD is being configured
-    modeElite:       false


### PR DESCRIPTION
Remove modeElite from all *-start.yml files, so that we abstract it and make it truly optional. It empowers us to change the values in the control files and making modeElite mandatory.