### PR TITLE
Pass applicationBluePrint to building code

### DIFF
--- a/templates/boot-strap.yml
+++ b/templates/boot-strap.yml
@@ -152,7 +152,7 @@ steps:
 # -----------------------------------------------------------------------
 - ${{ if and(eq( lower(parameters.bootstrapMode), 'runbuildingcodeonly' ), and(ne(lower(variables['Build.SourceBranchName']), 'merge'), eq( lower(parameters.forceCheck), false))) }}:
   - checkout:    self
-  - script:      echo Building Code Validations are suppressed! Only pull request validation builds are validated to optimise production builds. 
+  - script:      echo Building Code Validations are suppressed! Only pull request validation builds are validated to optimize production builds. 
     displayName: Bootstrap Building Code Validation Suppression Alert
 
 - ${{ if and(eq( lower(parameters.bootstrapMode), 'runbuildingcodeonly' ), or(eq(lower(variables['Build.SourceBranchName']), 'merge'), eq( lower(parameters.forceCheck), true))) }}:
@@ -163,6 +163,7 @@ steps:
       portfolioName:          ${{parameters.portfolioName}}
       productName:            ${{parameters.productName}}
       buildingCodeMode:       'Validate' # Validate | Enforce
+      applicationBlueprint:   ${{parameters.applicationBlueprint}}
       verbose:                ${{parameters.verbose}}
       modeElite:              ${{parameters.modeElite}}
 
@@ -191,6 +192,7 @@ steps:
       productName:            ${{parameters.productName}}
       cliSources:             ${{parameters.sourcesDirectory}}
       buildingCodeMode:       'Validate' # Validate | Enforce
+      applicationBlueprint:   ${{parameters.applicationBlueprint}}
       verbose:                ${{parameters.verbose}}
       modeElite:              ${{parameters.modeElite}}
 

--- a/templates/building-code/building-code.yml
+++ b/templates/building-code/building-code.yml
@@ -18,6 +18,9 @@ parameters:
 - name:     buildingCodeMode
   type:     string
   default:  'Validate' # Validate | Enforce
+- name:     applicationBlueprint
+  type:     string
+  default:  'generic'
 - name:     verbose
   type:     boolean
   default:  false
@@ -27,7 +30,7 @@ parameters:
   
 steps:
 - ${{ if eq( parameters.verbose, true ) }}: 
-  - script: echo BuildingCode parameters >> AT = ${{parameters.applicationType}}, PON = ${{parameters.portfolioName}}, PRN = ${{parameters.productName}}, BCM = ${{parameters.buildingCodeMode}}, ME = ${{parameters.modeElite}}
+  - script: echo BuildingCode parameters >> AT = ${{parameters.applicationType}}, PON = ${{parameters.portfolioName}}, PRN = ${{parameters.productName}}, BCM = ${{parameters.buildingCodeMode}}, ME = ${{parameters.modeElite}}, BC = ${{parameters.applicationBlueprint}}
     displayName: Bootstrap Building Code Verbose Logging
 
 # ======================================================================


### PR DESCRIPTION
Pass applicationBluePrint to building code so that building code can make decisions on both application and blueprint type.