### PR TITLE
Adding the platform as part of the build config

### DIFF
--- a/blueprints/nuget-package/azure-pipeline-nuget-package-ci.yml
+++ b/blueprints/nuget-package/azure-pipeline-nuget-package-ci.yml
@@ -128,7 +128,7 @@ stages:
         inputs:
           command:          'build'
           projects:         '$(Build.SourcesDirectory)\${{parameters.projectPath}}\${{parameters.projectFile}}'
-          arguments:        "--configuration $(buildConfiguration) --no-restore /p:Version=$(setSemVersion.semVersion)"
+          arguments:        "--configuration $(buildConfiguration) --arch ${{parameters.platform}} --no-restore /p:Version=$(setSemVersion.semVersion)"
     - ${{ else }}:
       - task: VSBuild@1
         displayName: 'Build'


### PR DESCRIPTION
Adding the platform as part of the build configuration settings
Restoring buildConfiguration