### PR TITLE
Sync revisions

### DIFF
--- a/blueprints/azure-function/azure-pipeline-azure-function-cd-stage.yml
+++ b/blueprints/azure-function/azure-pipeline-azure-function-cd-stage.yml
@@ -9,18 +9,23 @@ parameters:
   type:     string
 - name:     azRmWebDeployAzureSubscription
   type:     string
+- name:     azResourceGroup
+  type:     string
 - name:     azRmWebDeployWebAppName
   type:     string
 - name:     azFuncProjectName
   type:     string
-- name:     dependsOn
-  type:     object
 - name:     azureFunctionType
   type:     string
-- name:     runtimeStack
+- name:     functionExtensionVersion
   type:     string
+- name:     windowsRuntimeStack
+  type:     string
+- name:     linuxRuntimeStack
+  type:     string
+- name:     dependsOn
+  type:     object
   default:  []
-
 stages:
 
 # -----------------------------------------------------------------------------------------------------
@@ -45,8 +50,34 @@ stages:
           - task: AzureFunctionApp@2
             displayName: Deploy Azure Function
             inputs:
-              azureSubscription:  ${{parameters.azRmWebDeployAzureSubscription}}
-              azureType: ${{parameters.azureFunctionType}}
+              azureSubscription: ${{parameters.azRmWebDeployAzureSubscription}}
+              appType: ${{parameters.azureFunctionType}}
               appName: ${{parameters.azRmWebDeployWebAppName}}
               package: '$(Pipeline.Workspace)/**/${{parameters.azFuncProjectName}}.zip'
-              runtimeStack: ${{parameters.runtimeStack}}
+              runtimeStack: ${{parameters.linuxRuntimeStack}}
+          - task: AzureCLI@2
+            displayName: Set Azure Function Runtime
+            inputs:
+              azureSubscription: ${{parameters.azRmWebDeployAzureSubscription}}
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                az functionapp config appsettings set --settings FUNCTIONS_EXTENSION_VERSION=${{parameters.functionExtensionVersion}} -g ${{parameters.azResourceGroup}} -n ${{parameters.azRmWebDeployWebAppName}}
+          - task: AzureCLI@2
+            displayName: Set Azure Function .Net Version - Windows
+            condition: eq( '${{ parameters.azureFunctionType }}', 'functionApp')
+            inputs:
+              azureSubscription: ${{parameters.azRmWebDeployAzureSubscription}}
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                az functionapp config set --net-framework-version ${{parameters.windowsRuntimeStack}} -g ${{parameters.azResourceGroup}} -n ${{parameters.azRmWebDeployWebAppName}}
+          - task: AzureCLI@2
+            displayName: Set Azure Function .Net Version - Linux
+            condition: eq('${{ parameters.azureFunctionType }}', 'functionAppLinux')
+            inputs:
+              azureSubscription: ${{parameters.azRmWebDeployAzureSubscription}}
+              scriptType: pscore
+              scriptLocation: inlineScript
+              inlineScript: |
+                az functionapp config set --name ${{parameters.azRmWebDeployWebAppName}} --resource-group ${{parameters.azResourceGroup}} --linux-fx-version "${{parameters.linuxRuntimeStack}}"

--- a/blueprints/azure-function/azure-pipeline-azure-function-cd.yml
+++ b/blueprints/azure-function/azure-pipeline-azure-function-cd.yml
@@ -14,10 +14,13 @@ stages:
       vmImage:                        ${{parameters.stage.development.vmImage}}
       envName:                        ${{parameters.stage.development.envName}}
       azRmWebDeployAzureSubscription: ${{parameters.stage.development.azRmWebDeployAzureSubscription}}
+      azResourceGroup:                ${{parameters.stage.development.azResourceGroup}}
       azRmWebDeployWebAppName:        ${{parameters.stage.development.azRmWebDeployWebAppName}}
       azFuncProjectName:              ${{parameters.stage.azFuncProjectName}}
       azureFunctionType:              ${{parameters.stage.azureFunctionType}}
-      runtimeStack:                   ${{parameters.stage.runtimeStack}}
+      functionExtensionVersion:       ${{parameters.stage.functionExtensionVersion}}
+      windowsRuntimeStack:            ${{parameters.stage.windowsRuntimeStack}}
+      linuxRuntimeStack:              ${{parameters.stage.linuxRuntimeStack}}
       dependsOn:
       - ContinuousIntegration
 
@@ -32,10 +35,13 @@ stages:
       vmImage:                        ${{parameters.stage.systemTest.vmImage}}
       envName:                        ${{parameters.stage.systemTest.envName}}
       azRmWebDeployAzureSubscription: ${{parameters.stage.systemTest.azRmWebDeployAzureSubscription}}
+      azResourceGroup:                ${{parameters.stage.systemTest.azResourceGroup}}
       azRmWebDeployWebAppName:        ${{parameters.stage.systemTest.azRmWebDeployWebAppName}}
       azFuncProjectName:              ${{parameters.stage.azFuncProjectName}}
       azureFunctionType:              ${{parameters.stage.azureFunctionType}}
-      runtimeStack:                   ${{parameters.stage.runtimeStack}}
+      functionExtensionVersion:       ${{parameters.stage.functionExtensionVersion}}
+      windowsRuntimeStack:            ${{parameters.stage.windowsRuntimeStack}}
+      linuxRuntimeStack:              ${{parameters.stage.linuxRuntimeStack}}
       dependsOn:
       - ContinuousIntegration
       - ${{ if eq(parameters.stage.development.name, 'Development') }}:
@@ -96,10 +102,13 @@ stages:
       vmImage:                        ${{parameters.stage.staging.vmImage}}
       envName:                        ${{parameters.stage.staging.envName}}
       azRmWebDeployAzureSubscription: ${{parameters.stage.staging.azRmWebDeployAzureSubscription}}
+      azResourceGroup:                ${{parameters.stage.staging.azResourceGroup}}
       azRmWebDeployWebAppName:        ${{parameters.stage.staging.azRmWebDeployWebAppName}}
       azFuncProjectName:              ${{parameters.stage.azFuncProjectName}}
       azureFunctionType:              ${{parameters.stage.azureFunctionType}}
-      runtimeStack:                   ${{parameters.stage.runtimeStack}}
+      functionExtensionVersion:       ${{parameters.stage.functionExtensionVersion}}
+      windowsRuntimeStack:            ${{parameters.stage.windowsRuntimeStack}}
+      linuxRuntimeStack:              ${{parameters.stage.linuxRuntimeStack}}
       dependsOn:
       - ContinuousIntegration
       - ${{ if eq(parameters.stage.development.name, 'Development') }}:
@@ -141,10 +150,13 @@ stages:
       vmImage:                        ${{parameters.stage.production.vmImage}}
       envName:                        ${{parameters.stage.production.envName}}
       azRmWebDeployAzureSubscription: ${{parameters.stage.production.azRmWebDeployAzureSubscription}}
+      azResourceGroup:                ${{parameters.stage.production.azResourceGroup}}
       azRmWebDeployWebAppName:        ${{parameters.stage.production.azRmWebDeployWebAppName}}
       azFuncProjectName:              ${{parameters.stage.azFuncProjectName}}
       azureFunctionType:              ${{parameters.stage.azureFunctionType}}
-      runtimeStack:                   ${{parameters.stage.runtimeStack}}
+      functionExtensionVersion:       ${{parameters.stage.functionExtensionVersion}}
+      windowsRuntimeStack:            ${{parameters.stage.windowsRuntimeStack}}
+      linuxRuntimeStack:              ${{parameters.stage.linuxRuntimeStack}}
       dependsOn:
       - ContinuousIntegration
       - ${{ if eq(parameters.stage.development.name, 'Development') }}:

--- a/blueprints/azure-function/azure-pipeline-azure-function-config.yml
+++ b/blueprints/azure-function/azure-pipeline-azure-function-config.yml
@@ -20,6 +20,8 @@ variables:
   value: 'ubuntu-latest'
 - name:  developmentStageAzRmWebDeployAzureSubscription
   value: '<TBD>'
+- name:  developmentStageAzResourceGroup
+  value: '<TBD>'
 - name:  developmentStageAzRmWebDeployWebAppName
   value: '<TBD>'
 
@@ -33,6 +35,8 @@ variables:
 - name:  systemTestStageVmImage
   value: 'ubuntu-latest'
 - name:  systemTestStageAzRmWebDeployAzureSubscription
+  value: '<TBD>'
+- name:  systemTestStageAzResourceGroup
   value: '<TBD>'
 - name:  systemTestStageAzRmWebDeployWebAppName
   value: '<TBD>'
@@ -54,6 +58,8 @@ variables:
   value: 'ubuntu-latest'
 - name:  stagingStageAzRmWebDeployAzureSubscription
   value: '<TBD>'
+- name:  systemTestStageAzResourceGroup
+  value: '<TBD>'
 - name:  stagingStageAzRmWebDeployWebAppName
   value: '<TBD>'
 
@@ -67,6 +73,8 @@ variables:
 - name:  productionStageVmImage
   value: 'ubuntu-latest'
 - name:  productionStageAzRmWebDeployAzureSubscription
+  value: '<TBD>'
+- name:  systemTestStageAzResourceGroup
   value: '<TBD>'
 - name:  productionStageAzRmWebDeployWebAppName
   value: '<TBD>'

--- a/blueprints/azure-function/azure-pipeline-azure-function-control.yml
+++ b/blueprints/azure-function/azure-pipeline-azure-function-control.yml
@@ -14,9 +14,6 @@ parameters:
 - name:     azureFunctionType
   type:     string
   default:  'functionAppLinux'
-- name:     runtimeStack
-  type:     string
-  default:  'DOTNET|6.0'
 - name:     modeElite
   type:     boolean
   default:  false
@@ -37,6 +34,20 @@ parameters:
 variables:
 - ${{ if ne(parameters.suppressCD, true) }}:
   - template: /deploy/${{ lower(parameters.portfolioName) }}/${{ lower(parameters.productName) }}-config.yml@CeConfiguration
+
+# -----------------------------------------------------------------------------------------------------
+# Azure Function App Settings
+# These are set for the current LTS supported versions of .Net and current Azure Function Runtime.
+# NOTE: when we move to .Net 8 (LTS) and possibly running the function in isolation mode,
+#       we will need to adjust these settings. At that point we will probably need to add a
+#       parameter for in-process vs. isolated worker process (preferred)
+# -----------------------------------------------------------------------------------------------------
+- name:  fxnExtensionVersion
+  value: '~4'
+- name:  windowsDotNetVersion
+  value: 'v6.0'
+- name:  linuxDotNetVersion
+  value: 'DOTNET|6.0'
 
 stages:
 
@@ -64,12 +75,15 @@ stages:
       stage:
         azFuncProjectName:                ${{parameters.azFuncProjectName}}
         azureFunctionType:                ${{parameters.azureFunctionType}}
-        runtimeStack:                     ${{parameters.runtimeStack}}
+        functionExtensionVersion:         ${{variables.fxnExtensionVersion}}
+        linuxRuntimeStack:                ${{variables.linuxDotNetVersion}}
+        windowsRuntimeStack:              ${{variables.windowsDotNetVersion}}
         development:
           name:                           ${{variables.developmentStageName}}
           vmImage:                        ${{variables.developmentStageVmImage}}
           envName:                        ${{variables.developmentStageEnvName}}
           azRmWebDeployAzureSubscription: ${{variables.developmentStageAzRmWebDeployAzureSubscription}}
+          azResourceGroup:                ${{variables.developmentStageAzResourceGroup}}
           azRmWebDeployWebAppName:        ${{variables.developmentStageAzRmWebDeployWebAppName}}
           applicationBlueprint:           ${{parameters.applicationBlueprint}}
           modeElite:                      ${{parameters.modeElite}}
@@ -78,6 +92,7 @@ stages:
           vmImage:                        ${{variables.systemTestStageVmImage}}
           envName:                        ${{variables.systemTestStageEnvName}}
           azRmWebDeployAzureSubscription: ${{variables.systemTestStageAzRmWebDeployAzureSubscription}}
+          azResourceGroup:                ${{variables.systemTestStageAzResourceGroup}}
           azRmWebDeployWebAppName:        ${{variables.systemTestStageAzRmWebDeployWebAppName}}
           applicationBlueprint:           ${{parameters.applicationBlueprint}}
           modeElite:                      ${{parameters.modeElite}}
@@ -86,6 +101,7 @@ stages:
           vmImage:                        ${{variables.stagingStageVmImage}}
           envName:                        ${{variables.stagingStageEnvName}}
           azRmWebDeployAzureSubscription: ${{variables.stagingStageAzRmWebDeployAzureSubscription}}
+          azResourceGroup:                ${{variables.stagingStageAzResourceGroup}}
           azRmWebDeployWebAppName:        ${{variables.stagingStageAzRmWebDeployWebAppName}}
           applicationBlueprint:           ${{parameters.applicationBlueprint}}
           modeElite:                      ${{parameters.modeElite}}
@@ -94,6 +110,7 @@ stages:
           vmImage:                        ${{variables.productionStageVmImage}}
           envName:                        ${{variables.productionStageEnvName}}
           azRmWebDeployAzureSubscription: ${{variables.productionStageAzRmWebDeployAzureSubscription}}
+          azResourceGroup:                ${{variables.productionStageAzResourceGroup}}
           azRmWebDeployWebAppName:        ${{variables.productionStageAzRmWebDeployWebAppName}}
           applicationBlueprint:           ${{parameters.applicationBlueprint}}
           modeElite:                      ${{parameters.modeElite}}

--- a/blueprints/azure-function/azure-pipeline-azure-function-start.yml
+++ b/blueprints/azure-function/azure-pipeline-azure-function-start.yml
@@ -38,5 +38,4 @@ extends:
     productName:        '__TODO_PRODUCT__'
     azFuncProjectName:  '__TODO_AZURE_FUNCTION_PROJECT_NAME__' # e.g. CeS.Sample.AzureFunction
     azureFunctionType:  '__TODO_AZURE_FUNCTION_TYPE__'         # either 'functionApp' or 'functionAppLinux'
-    runtimeStack:       '__TODO_AZURE_FUNCTION_RUNTIME__'      # defaults to 'DOTNET|6.0'
     suppressCD:         true # Allow engineering to do an immediate CI/build while CD is being configured


### PR DESCRIPTION
Adds Azure CLI calls that updates the .Net version and runtime settings for the Azure Function infrastructure (as opposed to the settings in the code which are also required).

As part of these changes I needed to change some of the blueprint configuration:

In the start.yml, the runtimeVersion is removed.
In the config.yml, the resource group is now required. I have updated these for the config.yml of all existing azure functions.

In the control.yml there are current settings for the azure function runtime and .net version which are defined to be ~4 and .Net 6. If/when we need to update these settings, it can be done here.